### PR TITLE
Require thinc with ops registry

### DIFF
--- a/.github/azure-steps.yml
+++ b/.github/azure-steps.yml
@@ -32,6 +32,11 @@ steps:
       ${{ parameters.prefix }} python -m pip wheel . -w dist
     displayName: 'Build wheel'
 
+  - task: DeleteFiles@1
+    inputs:
+      contents: "thinc_apple_ops"
+    displayName: "Delete source directory"
+
   - script: |
       ${{ parameters.prefix }} python -m pip install -r requirements.txt
       ${{ parameters.prefix }} python -m pytest --pyargs thinc_apple_ops

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ trigger:
 
 jobs:
 
-- job: 'Tests X86'
+- job: 'TestsX86'
   strategy:
     matrix:
       Python39:
@@ -18,7 +18,7 @@ jobs:
       python_version: '$(python.version)'
       architecture: 'X64'
 
-- job: 'Tests ARM'
+- job: 'TestsARM'
   strategy:
     matrix:
       Python39MacARM64:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,12 +12,14 @@ jobs:
       Python39Mac:
         imageName: "macos-10.14"
         python.version: '3.9'
-
+  pool:
+      vmImage: $(imageName)
   steps:
   - template: .github/azure-steps.yml
     parameters:
       python_version: '$(python.version)'
       architecture: 'X64'
+
 
 - job: 'TestsARM'
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,8 @@ jobs:
 - job: 'TestsX86'
   strategy:
     matrix:
-      Python39:
+      Python39Mac:
+        imageName: "macos-10.14"
         python.version: '3.9'
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,19 @@ trigger:
 
 jobs:
 
-- job: 'Tests'
+- job: 'Tests X86'
+  strategy:
+    matrix:
+      Python39:
+        python.version: '3.9'
+
+  steps:
+  - template: .github/azure-steps.yml
+    parameters:
+      python_version: '$(python.version)'
+      architecture: 'X64'
+
+- job: 'Tests ARM'
   strategy:
     matrix:
       Python39MacARM64:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,5 @@ requires = [
     "setuptools",
     "cython>=0.25",
     "numpy>=1.21.0",
-    "thinc>=8.0.9",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools",
     "cython>=0.25",
     "numpy>=1.21.0",
+    "thinc>=8.0.9",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cython>=0.25
 numpy>=1.21.0
+thinc>=8.0.9
 # dev
 pytest>=5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.25
 numpy>=1.21.0
-thinc>=8.0.9
+thinc>=8.0.10
 # dev
 pytest>=5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     numpy>=1.21.0
-    thinc>=8.0.9
+    thinc>=8.0.10
 
 [options.entry_points]
 thinc_ops =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     numpy>=1.21.0
+    thinc>=8.0.9
 
 [options.entry_points]
 thinc_ops =

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ import os
 import sys
 import numpy
 
-from setuptools import Extension, setup
+from setuptools import Extension, setup, find_packages
 from Cython.Build import cythonize
 
 
-PACKAGES = ["thinc_apple_ops"]
+PACKAGES = find_packages()
 MOD_NAMES = ["thinc_apple_ops.blas"]
 
 

--- a/thinc_apple_ops/ops.py
+++ b/thinc_apple_ops/ops.py
@@ -1,14 +1,9 @@
 from typing import Optional
 import numpy
+from thinc.api import NumpyOps
+from thinc.types import Floats2d
 from . import blas
 
-try:
-    from thinc.api import NumpyOps
-    from thinc.types import Floats2d
-except ImportError:
-    class NumpyOps:
-        pass
-    Floats2d = numpy.ndarray
     
 class AppleOps(NumpyOps):
     """Thinc Ops class that calls into Apple's native libraries for some


### PR DESCRIPTION
Technically it doesn't require a currently unreleased version of thinc to run, but if people install it into an existing venv, then it's better to require the version of thinc to upgraded so that it's detected and used.