### PR TITLE
Fix 0-size arrays

### DIFF
--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -41,6 +41,8 @@ cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, bint trans1=False, bint 
     cdef np.ndarray out = numpy.zeros((nM, nN), dtype="f")
 
     cdef float[:, ::1] C = out
+    if nM == 0 or nK == 0 or nN == 0:
+        return out
 
     cblas_sgemm(
         CblasRowMajor,

--- a/thinc_apple_ops/tests/test_gemm.py
+++ b/thinc_apple_ops/tests/test_gemm.py
@@ -1,3 +1,4 @@
+import pytest
 import thinc_apple_ops.blas
 import numpy
 
@@ -7,3 +8,29 @@ def test_basic_sgemm():
     B = numpy.ndarray((4, 7), dtype="f")
     C = thinc_apple_ops.blas.gemm(A, B)
     assert C.shape == (A.shape[0], B.shape[1])
+
+
+@pytest.mark.parametrize("A_shape,B_shape,transA,transB", [
+    [(0, 0), (0, 0), False, False],
+    [(0, 0), (0, 0), True, False],
+    [(0, 0), (0, 0), False, True],
+    [(0, 0), (0, 0), True, True],
+    [(0, 5), (5, 0), False, False],
+    [(5, 0), (5, 0), False, True],
+    [(5, 0), (5, 0), True, False]
+])
+def test_zero_size(A_shape, B_shape, transA, transB):
+    A = numpy.ndarray(A_shape, dtype="f")
+    B = numpy.ndarray(B_shape, dtype="f")
+    if not transA and not transB:
+        C = numpy.dot(A, B)
+    elif transA:
+        C = numpy.dot(A.T, B)
+    elif transB:
+        C = numpy.dot(A, B.T)
+    else:
+        C = numpy.dot(A.T, B.T)
+    C_ = thinc_apple_ops.blas.gemm(A, B, trans1=transA, trans2=transB)
+    assert C.shape == C_.shape
+
+


### PR DESCRIPTION
Our bit of Cython code uses memory buffers, which apparently have a bounds-check when the size is 0 when acquiring the pointer. In contrast, in other bits of code we often acquire the buffer by casting the `array.data` pointer, which has no such bounds check. This led to `IndexError` being raised when zero shapes were passed through.