### PR TITLE
AppleOps.gemm: check shape

### DIFF
--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -42,7 +42,7 @@ cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, bint trans1=False, bint 
     cdef np.ndarray out = numpy.empty((nM, nN), dtype="f")
 
     if nK != nK_b:
-        msg = "Shape mismatch for blis.gemm: (%d, %d), (%d, %d)"
+        msg = "Shape mismatch for gemm: (%d, %d), (%d, %d)"
         raise ValueError(msg % (nM, nK, nK_b, nN))
 
     cdef float[:, ::1] C = out

--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -37,8 +37,13 @@ cdef extern from "Accelerate/Accelerate.h":
 cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, bint trans1=False, bint trans2=False): 
     cdef int nM = A.shape[0] if not trans1 else A.shape[1]
     cdef int nK = A.shape[1] if not trans1 else A.shape[0]
+    cdef int nK_b = B.shape[0] if not trans2 else B.shape[1]
     cdef int nN = B.shape[1] if not trans2 else B.shape[0]
     cdef np.ndarray out = numpy.empty((nM, nN), dtype="f")
+
+    if nK != nK_b:
+        msg = "Shape mismatch for blis.gemm: (%d, %d), (%d, %d)"
+        raise ValueError(msg % (nM, nK, nK_b, nN))
 
     cdef float[:, ::1] C = out
     if nM == 0 or nK == 0 or nN == 0:

--- a/thinc_apple_ops/tests/test_gemm.py
+++ b/thinc_apple_ops/tests/test_gemm.py
@@ -34,3 +34,17 @@ def test_zero_size(A_shape, B_shape, transA, transB):
     assert C.shape == C_.shape
 
 
+@pytest.mark.parametrize(
+    "A_shape,B_shape,transA,transB",
+    [
+        [(4, 5), (4, 5), False, False],
+        [(5, 4), (4, 5), True, False],
+        [(4, 5), (5, 4), False, True],
+        [(5, 4), (5, 4), True, True],
+    ],
+)
+def test_incorrect_shapes(A_shape, B_shape, transA, transB):
+    A = numpy.ndarray(A_shape, dtype="f")
+    B = numpy.ndarray(B_shape, dtype="f")
+    with pytest.raises(ValueError, match=r"Shape mismatch"):
+        thinc_apple_ops.blas.gemm(A, B, trans1=transA, trans2=transB)


### PR DESCRIPTION
Before this change, using `AppleOps.gemm` returned garbage when used
with incorrect shapes. Raise an exception instead.
