### PR TITLE
Pass through Accelerate sgemm/saxpy in Ops.cblas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.25
 numpy>=1.21.0
-thinc>=8.0.13,<9.0.0
+thinc>=8.1.0.dev0,<9.0.0
 # dev
 pytest>=5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     numpy>=1.21.0
-    thinc>=8.0.13,<9.0.0
+    thinc>=8.1.0.dev0,<9.0.0
 
 [options.entry_points]
 thinc_ops =

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,12 @@ def setup_package():
             include_dirs=[numpy.get_include()],
             libraries=["blas"],
         ),
+        Extension(
+            "thinc_apple_ops.ops",
+            ["thinc_apple_ops/ops.pyx"],
+            language="c++",
+            include_dirs=[numpy.get_include()],
+        ),
     ]
 
     setup(

--- a/thinc_apple_ops/blas.pxd
+++ b/thinc_apple_ops/blas.pxd
@@ -1,0 +1,40 @@
+cdef extern from "Accelerate/Accelerate.h":
+    enum CBLAS_ORDER:     CblasRowMajor, CblasColMajor
+    enum CBLAS_TRANSPOSE: CblasNoTrans, CblasTrans, CblasConjTrans
+    enum CBLAS_UPLO:      CblasUpper, CblasLower
+    enum CBLAS_DIAG:      CblasNonUnit, CblasUnit
+    enum CBLAS_SIDE:      CblasLeft, CblasRight
+
+    # BLAS level 1 routines
+
+    void cblas_sswap(int M, float  *x, int incX, float  *y, int incY) nogil
+    void cblas_sscal(int N, float  alpha, float  *x, int incX) nogil
+    void cblas_scopy(int N, float  *x, int incX, float  *y, int incY) nogil
+    void cblas_saxpy(int N, float  alpha, float  *x, int incX, float  *y, int incY ) nogil
+    float cblas_sdot(int N, float  *x, int incX, float  *y, int incY ) nogil
+    float cblas_snrm2(int N, float  *x, int incX) nogil
+    float cblas_sasum(int N, float  *x, int incX) nogil
+    int cblas_isamax(int N, float  *x, int incX) nogil
+
+    # BLAS level 2 routines
+    void cblas_sgemv(CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA, int M, int N,
+                                 float  alpha, float  *A, int lda, float  *x, int incX,
+                                 float  beta, float  *y, int incY) nogil
+
+    void cblas_sger(CBLAS_ORDER Order, int M, int N, float  alpha, float  *x,
+                                int incX, float  *y, int incY, float  *A, int lda) nogil
+
+    # BLAS level 3 routines
+    void cblas_sgemm(CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA,
+                                 CBLAS_TRANSPOSE TransB, int M, int N, int K,
+                                 float  alpha, float  *A, int lda, float  *B, int ldb,
+                                 float  beta, float  *C, int ldc) nogil
+
+
+cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
+                    float alpha, const float* A, int lda, const float *B,
+                    int ldb, float beta, float* C, int ldc) nogil
+
+
+cdef void saxpy(int N, float alpha, const float* X, int incX,
+                float *Y, int incY) nogil

--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -1,37 +1,6 @@
+from libc.stdint cimport uintptr_t
 cimport numpy as np
 import numpy
-
-cdef extern from "Accelerate/Accelerate.h":
-    enum CBLAS_ORDER:     CblasRowMajor, CblasColMajor
-    enum CBLAS_TRANSPOSE: CblasNoTrans, CblasTrans, CblasConjTrans
-    enum CBLAS_UPLO:      CblasUpper, CblasLower
-    enum CBLAS_DIAG:      CblasNonUnit, CblasUnit
-    enum CBLAS_SIDE:      CblasLeft, CblasRight
-
-    # BLAS level 1 routines
-
-    void cblas_sswap(int M, float  *x, int incX, float  *y, int incY) nogil
-    void cblas_sscal(int N, float  alpha, float  *x, int incX) nogil
-    void cblas_scopy(int N, float  *x, int incX, float  *y, int incY) nogil
-    void cblas_saxpy(int N, float  alpha, float  *x, int incX, float  *y, int incY ) nogil
-    float cblas_sdot(int N, float  *x, int incX, float  *y, int incY ) nogil
-    float cblas_snrm2(int N, float  *x, int incX) nogil
-    float cblas_sasum(int N, float  *x, int incX) nogil
-    int cblas_isamax(int N, float  *x, int incX) nogil
-
-    # BLAS level 2 routines
-    void cblas_sgemv(CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA, int M, int N,
-                                 float  alpha, float  *A, int lda, float  *x, int incX,
-                                 float  beta, float  *y, int incY) nogil
-
-    void cblas_sger(CBLAS_ORDER Order, int M, int N, float  alpha, float  *x,
-                                int incX, float  *y, int incY, float  *A, int lda) nogil
-
-    # BLAS level 3 routines
-    void cblas_sgemm(CBLAS_ORDER Order, CBLAS_TRANSPOSE TransA,
-                                 CBLAS_TRANSPOSE TransB, int M, int N, int K,
-                                 float  alpha, float  *A, int lda, float  *B, int ldb,
-                                 float  beta, float  *C, int ldc) nogil
 
 
 cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, bint trans1=False, bint trans2=False): 
@@ -66,3 +35,29 @@ cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, bint trans1=False, bint 
         C.shape[1]
     )
     return out
+
+
+cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
+                    float alpha, const float* A, int lda, const float *B,
+                    int ldb, float beta, float* C, int ldc) nogil:
+    cblas_sgemm(
+        CblasRowMajor,
+        CblasTrans if TransA else CblasNoTrans,
+        CblasTrans if TransB else CblasNoTrans,
+        M,
+        N,
+        K,
+        alpha,
+        A,
+        lda,
+        B,
+        ldb,
+        beta,
+        C,
+        ldc
+    )
+
+
+cdef void saxpy(int N, float alpha, const float* X, int incX,
+                float *Y, int incY) nogil:
+    cblas_saxpy(N, alpha, X, incX, Y, incY)

--- a/thinc_apple_ops/ops.pyx
+++ b/thinc_apple_ops/ops.pyx
@@ -1,15 +1,23 @@
 from typing import Optional
 import numpy
 from thinc.api import NumpyOps
+from thinc.backends.cblas cimport CBlas
 from thinc.types import Floats2d
 from . import blas
+from .blas cimport saxpy, sgemm
 
-    
+
 class AppleOps(NumpyOps):
     """Thinc Ops class that calls into Apple's native libraries for some
     operations. Other operations fall back to numpy."""
     name = "apple"
     xp = numpy
+
+    def cblas(self) -> CBlas:
+        cdef CBlas cblas = CBlas()
+        cblas.set_saxpy(saxpy)
+        cblas.set_sgemm(sgemm)
+        return cblas
 
     def gemm(
         self,


### PR DESCRIPTION
This can be used by e.g. the parser in spaCy 3.4 to use Accelerate's  implementations.

I am not sure how to handle this dependency-wise, since this requires  Thinc 8.1, but we still want to people to be able to use thinc-apple-ops with Thinc 8.0.x and spaCy < 3.4. Do we need another minor release that sets thinc < 8.1.0?
