### PR TITLE
Change thinc upper bound to <8.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.25
 numpy>=1.21.0
-thinc>=8.0.13,<9.0.0
+thinc>=8.0.13,<8.1.0
 # dev
 pytest>=5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 description = Improve Thinc's performance on Apple devices with native libraries
-version = 0.0.6
+version = 0.0.7
 url = https://github.com/explosion/thinc-apple-ops
 author = Explosion
 author_email = contact@explosion.ai

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     numpy>=1.21.0
-    thinc>=8.0.13,<9.0.0
+    thinc>=8.0.13,<8.1.0
 
 [options.entry_points]
 thinc_ops =


### PR DESCRIPTION
thinc-apple-ops will require thinc >= 8.1.0 in the future for the CBLAS passthrough functionality. As discussed in #15, we should first do another minor thinc-apple-ops release specifically for thinc <8.1.0.

Also bump the version to v0.0.7 to prepare for the release.