### PR TITLE
Import NumpyOps from its backend module

### DIFF
--- a/thinc_apple_ops/ops.py
+++ b/thinc_apple_ops/ops.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import numpy
-from thinc.api import NumpyOps
+from thinc.backends.numpy_ops import NumpyOps
 from thinc.types import Floats2d
 from . import blas
 


### PR DESCRIPTION
This allows us to conditionally import AppleOps in Thinc.
