### PR TITLE
AppleOps.gemm: write in-place when `output` is given

### DIFF
--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -3,18 +3,28 @@ cimport numpy as np
 import numpy
 
 
-cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, bint trans1=False, bint trans2=False): 
+cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, np.ndarray out=None,
+                      bint trans1=False, bint trans2=False):
     cdef int nM = A.shape[0] if not trans1 else A.shape[1]
     cdef int nK = A.shape[1] if not trans1 else A.shape[0]
     cdef int nK_b = B.shape[0] if not trans2 else B.shape[1]
     cdef int nN = B.shape[1] if not trans2 else B.shape[0]
-    cdef np.ndarray out = numpy.empty((nM, nN), dtype="f")
+
+    cdef float[:, ::1] C = out
+
+    if out is None:
+        out = numpy.empty((nM, nN), dtype="f")
+        C = out
+    else:
+        if C.shape[0] != nM or C.shape[1] != nN:
+            msg = "Shape mismatch for output matrix, was: (%d, %d), expected (%d, %d)"
+            raise ValueError(msg % (C.shape[0], C.shape[1], nM, nN))
+
 
     if nK != nK_b:
         msg = "Shape mismatch for gemm: (%d, %d), (%d, %d)"
         raise ValueError(msg % (nM, nK, nK_b, nN))
 
-    cdef float[:, ::1] C = out
     if nM == 0 or nK == 0 or nN == 0:
         return out
 

--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -3,8 +3,9 @@ cimport numpy as np
 import numpy
 
 
-cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B, np.ndarray out=None,
-                      bint trans1=False, bint trans2=False):
+cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B,
+                      bint trans1=False, bint trans2=False,
+                      np.ndarray out=None):
     cdef int nM = A.shape[0] if not trans1 else A.shape[1]
     cdef int nK = A.shape[1] if not trans1 else A.shape[0]
     cdef int nK_b = B.shape[0] if not trans2 else B.shape[1]

--- a/thinc_apple_ops/ops.pyx
+++ b/thinc_apple_ops/ops.pyx
@@ -30,9 +30,4 @@ class AppleOps(NumpyOps):
         """Perform General Matrix Multiplication (GeMM) and optionally store
         the result in the specified output variable.
         """
-        C = blas.gemm(x, y, trans1=trans1, trans2=trans2)
-        if out is None:
-            return C
-        else:
-            out[:] = C
-            return out
+        return blas.gemm(x, y, out=out, trans1=trans1, trans2=trans2)

--- a/thinc_apple_ops/tests/test_gemm.py
+++ b/thinc_apple_ops/tests/test_gemm.py
@@ -4,21 +4,40 @@ import numpy
 
 
 def test_basic_sgemm():
-    A = numpy.ndarray((5, 4), dtype="f")
-    B = numpy.ndarray((4, 7), dtype="f")
+    A = numpy.random.randn(5, 4).astype("f")
+    B = numpy.random.randn(4, 7).astype("f")
     C = thinc_apple_ops.blas.gemm(A, B)
     assert C.shape == (A.shape[0], B.shape[1])
 
+    C_out = numpy.empty((5, 7), dtype="f")
+    thinc_apple_ops.blas.gemm(A, B, out=C_out)
 
-@pytest.mark.parametrize("A_shape,B_shape,transA,transB", [
-    [(0, 0), (0, 0), False, False],
-    [(0, 0), (0, 0), True, False],
-    [(0, 0), (0, 0), False, True],
-    [(0, 0), (0, 0), True, True],
-    [(0, 5), (5, 0), False, False],
-    [(5, 0), (5, 0), False, True],
-    [(5, 0), (5, 0), True, False]
-])
+    numpy.testing.assert_allclose(C, C_out)
+
+
+def test_incorrect_output_size():
+    A = numpy.ndarray((5, 4), dtype="f")
+    B = numpy.ndarray((4, 7), dtype="f")
+
+    with pytest.raises(ValueError, match=r"Shape mismatch for output matrix"):
+        thinc_apple_ops.blas.gemm(A, B, out=numpy.ndarray((3, 7), dtype="f"))
+
+    with pytest.raises(ValueError, match=r"Shape mismatch for output matrix"):
+        thinc_apple_ops.blas.gemm(A, B, out=numpy.ndarray((5, 3), dtype="f"))
+
+
+@pytest.mark.parametrize(
+    "A_shape,B_shape,transA,transB",
+    [
+        [(0, 0), (0, 0), False, False],
+        [(0, 0), (0, 0), True, False],
+        [(0, 0), (0, 0), False, True],
+        [(0, 0), (0, 0), True, True],
+        [(0, 5), (5, 0), False, False],
+        [(5, 0), (5, 0), False, True],
+        [(5, 0), (5, 0), True, False],
+    ],
+)
 def test_zero_size(A_shape, B_shape, transA, transB):
     A = numpy.ndarray(A_shape, dtype="f")
     B = numpy.ndarray(B_shape, dtype="f")


### PR DESCRIPTION
NumpyOps.gemm (with BLIS) writes the result of matrix multiplication in-place when the `output` argument is given. This changes AppleOps.gemm to do the same, avoiding allocation of a temporary.