### PR TITLE
Update numpy build constraints for numpy 1.25

### DIFF
--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,5 +1,3 @@
 # build version constraints for use with wheelwright + multibuild
-numpy==1.21.0; python_version<='3.9'
-numpy==1.21.3; python_version=='3.10'
-numpy==1.23.2; python_version=='3.11'
-numpy; python_version>='3.12'
+numpy==1.21.0; python_version<'3.9'
+numpy>=1.25.0; python_version>='3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = [
     "setuptools",
     "cython>=0.25",
-    "numpy>=1.21.0",
+    "numpy>=1.21.0; python_version < '3.9'",
+    "numpy>=1.25.0; python_version >= '3.9'",
     "thinc>=8.1.0.dev2,<9.1.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Starting in numpy 1.25 (see
https://github.com/numpy/numpy/releases/tag/v1.25.0), the numpy C API is backwards-compatible by default.

For python 3.9+, we should be able to drop the specific numpy build requirements and use `numpy>=1.25`, which is currently backwards-compatible to `numpy>=1.19`.

In the future, the python <3.9 requirements could be dropped and the lower numpy pin could correspond to the oldest supported version for the current lower python pin.