### PR TITLE
fixes #41 - Added noexcept for cython 3.0 migration

### DIFF
--- a/thinc_apple_ops/blas.pxd
+++ b/thinc_apple_ops/blas.pxd
@@ -33,8 +33,8 @@ cdef extern from "Accelerate/Accelerate.h":
 
 cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
                     float alpha, const float* A, int lda, const float *B,
-                    int ldb, float beta, float* C, int ldc) nogil
+                    int ldb, float beta, float* C, int ldc) noexcept nogil
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float *Y, int incY) nogil
+                float *Y, int incY) noexcept nogil

--- a/thinc_apple_ops/blas.pyx
+++ b/thinc_apple_ops/blas.pyx
@@ -50,7 +50,7 @@ cpdef np.ndarray gemm(float[:, ::1] A, float[:, ::1] B,
 
 cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
                     float alpha, const float* A, int lda, const float *B,
-                    int ldb, float beta, float* C, int ldc) nogil:
+                    int ldb, float beta, float* C, int ldc) noexcept nogil:
     cblas_sgemm(
         CblasRowMajor,
         CblasTrans if TransA else CblasNoTrans,
@@ -70,5 +70,5 @@ cdef void sgemm(bint TransA, bint TransB, int M, int N, int K,
 
 
 cdef void saxpy(int N, float alpha, const float* X, int incX,
-                float *Y, int incY) nogil:
+                float *Y, int incY) noexcept nogil:
     cblas_saxpy(N, alpha, X, incX, Y, incY)


### PR DESCRIPTION
This is just a minimal fix to make the project compile with cython 3.
See the migration guide https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept